### PR TITLE
multiple instances of the player

### DIFF
--- a/js/sc-player.js
+++ b/js/sc-player.js
@@ -523,6 +523,8 @@
           // create the playlist
           $.each(tracks, function(index, track) {
             var active = index === 0;
+            // For Multiple instances of the player
+            $list = $('<ol class="sc-trackslist"></ol>').appendTo($player);
             // create an item in the playlist
             $('<li><a href="' + track.permalink_url +'">' + track.title + '</a><span class="sc-track-duration">' + timecode(track.duration) + '</span></li>').data('sc-track', {id:index}).toggleClass('active', active).appendTo($list);
             // create an item in the artwork list


### PR DESCRIPTION
Resolve this issue https://github.com/soundcloud/soundcloud-custom-player/issues/74#issue-27739585
by adding 

`$list = $('<ol class="sc-trackslist"></ol>').appendTo($player);`  

into the 

`$.each(tracks, function(index, track) { 
...
 }` 